### PR TITLE
Fixed the github icon link again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation](https://img.shields.io/badge/docs-hedtags.org-blue.svg)](https://www.hedtags.org/hed-resources) [![PyPI Version](https://img.shields.io/pypi/v/hed-resources.svg)](https://pypi.org/project/hed-resources/) [![License](https://img.shields.io/github/license/hed-standard/hed-resources.svg)](https://github.com/hed-standard/hed-resources/blob/main/LICENSE)
+[![Documentation](https://img.shields.io/badge/docs-hedtags.org-blue.svg)](https://www.hedtags.org/hed-resources) [![License](https://img.shields.io/github/license/hed-standard/hed-resources.svg)](https://github.com/hed-standard/hed-resources/blob/main/LICENSE)
 
 # HED Resources
 

--- a/docs/source/WhatsNew.md
+++ b/docs/source/WhatsNew.md
@@ -2,6 +2,10 @@
 
 # What's new?
 
+**Feb 1, 2026**: **HED discussions**
+
+> Organization-wide [HED discussions](https://github.com/orgs/hed-standard/discussions).
+
 **Jan 28, 2026**: **hed-vis 0.1.1 released**
 
 > Created standalone HED visualization tools repo.\
@@ -19,7 +23,7 @@
 
 **Nov 19, 2025**: **ctagger 4.0.0 released**
 
-> Update to Javas supported by MATALB.\
+> Update to Java versions supported by MATALB.\
 > Added GitHub actions.
 
 **Nov 18, 2025**: **hed-python 0.8.0 released**

--- a/docs/source/_static/gh_icon_fix.js
+++ b/docs/source/_static/gh_icon_fix.js
@@ -48,8 +48,10 @@ document.addEventListener("DOMContentLoaded", function() {
                     return repoName;
                 }
             }
+            return repoInHref;
         }
         
+        // For non-hed-resources repos (direct links to other repos), return the detected repo
         return repoInHref;
     }
 


### PR DESCRIPTION
The Github icon fix was inadvertently removed when the console logs were removed.